### PR TITLE
Hide commit info in last modified

### DIFF
--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,10 @@
+{{ if and (.GitInfo) (.Site.Params.github_repo) -}}
+<div class="text-muted mt-5 pt-3 border-top">
+  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+  <!--{{ with .GitInfo }}: {{/* Trim WS */ -}}
+    <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+      {{- .Subject }} ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
+    </a-->
+  {{- end }}
+</div>
+{{ end -}}


### PR DESCRIPTION
This change is to see if it's possible to hide the commit message in the 'last modified' information found at the bottom of the page.